### PR TITLE
Update the pin registers

### DIFF
--- a/401lightMessengerApp/401LightMsg_acc.c
+++ b/401lightMessengerApp/401LightMsg_acc.c
@@ -116,6 +116,10 @@ static void swipes_init(void* ctx, uint8_t direction) {
     AppContext* app = (AppContext*)ctx;
     AppAcc* appAcc = (AppAcc*)app->sceneAcc;
 
+    if(appAcc == NULL) {
+        return;
+    }
+
     if(appAcc->direction != direction) {
         if(appAcc->cyclesAvg != 0)
             appAcc->cyclesAvg = (appAcc->cyclesAvg + appAcc->cycles) / 2;

--- a/401lightMessengerApp/drivers/lis2xx12_wrapper.c
+++ b/401lightMessengerApp/drivers/lis2xx12_wrapper.c
@@ -15,11 +15,15 @@ int32_t lis2dh12_init(void* stmdev) {
     pin_int2_cfg.int_polarity = PARAM_INT_POLARITY;
     pin_int2_cfg.i2_ia1 = PROPERTY_DISABLE;
     pin_int2_cfg.i2_ia2 = PROPERTY_ENABLE;
+    pin_int2_cfg.not_used_01 = PROPERTY_DISABLE;
+    pin_int2_cfg.not_used_02 = PROPERTY_DISABLE;
     lis2dh12_pin_int2_config_set(stmdev, &pin_int2_cfg);
 
     pin_int1_cfg.i1_zyxda = PROPERTY_DISABLE;
     pin_int1_cfg.i1_ia1 = PROPERTY_ENABLE;
     pin_int1_cfg.i1_ia2 = PROPERTY_DISABLE;
+    pin_int1_cfg.not_used_01 = PROPERTY_DISABLE;
+    pin_int1_cfg.not_used_02 = PROPERTY_DISABLE;
     lis2dh12_pin_int1_config_set(stmdev, &pin_int1_cfg);
 
     // lis2dh12 general configuration

--- a/401lightMessengerApp/drivers/lis2xx12_wrapper.c
+++ b/401lightMessengerApp/drivers/lis2xx12_wrapper.c
@@ -5,12 +5,12 @@
 
 int32_t lis2dh12_init(void* stmdev) {
     // Interrupt registers
-    lis2dh12_int1_cfg_t int1_cfg;
-    lis2dh12_int2_cfg_t int2_cfg;
+    lis2dh12_int1_cfg_t int1_cfg = {0};
+    lis2dh12_int2_cfg_t int2_cfg = {0};
 
     // Pin registers
-    lis2dh12_ctrl_reg3_t pin_int1_cfg;
-    lis2dh12_ctrl_reg6_t pin_int2_cfg;
+    lis2dh12_ctrl_reg3_t pin_int1_cfg = {0};
+    lis2dh12_ctrl_reg6_t pin_int2_cfg = {0};
 
     pin_int2_cfg.int_polarity = PARAM_INT_POLARITY;
     pin_int2_cfg.i2_ia1 = PROPERTY_DISABLE;

--- a/401lightMessengerApp/drivers/lis2xx12_wrapper.c
+++ b/401lightMessengerApp/drivers/lis2xx12_wrapper.c
@@ -15,6 +15,9 @@ int32_t lis2dh12_init(void* stmdev) {
     pin_int2_cfg.int_polarity = PARAM_INT_POLARITY;
     pin_int2_cfg.i2_ia1 = PROPERTY_DISABLE;
     pin_int2_cfg.i2_ia2 = PROPERTY_ENABLE;
+    pin_int2_cfg.i2_boot = PROPERTY_DISABLE;
+    pin_int2_cfg.i2_act = PROPERTY_DISABLE;
+    pin_int2_cfg.i2_click = PROPERTY_DISABLE;
     pin_int2_cfg.not_used_01 = PROPERTY_DISABLE;
     pin_int2_cfg.not_used_02 = PROPERTY_DISABLE;
     lis2dh12_pin_int2_config_set(stmdev, &pin_int2_cfg);
@@ -22,6 +25,9 @@ int32_t lis2dh12_init(void* stmdev) {
     pin_int1_cfg.i1_zyxda = PROPERTY_DISABLE;
     pin_int1_cfg.i1_ia1 = PROPERTY_ENABLE;
     pin_int1_cfg.i1_ia2 = PROPERTY_DISABLE;
+    pin_int1_cfg.i1_click = PROPERTY_DISABLE;
+    pin_int1_cfg.i1_overrun = PROPERTY_DISABLE;
+    pin_int1_cfg.i1_wtm = PROPERTY_DISABLE;
     pin_int1_cfg.not_used_01 = PROPERTY_DISABLE;
     pin_int1_cfg.not_used_02 = PROPERTY_DISABLE;
     lis2dh12_pin_int1_config_set(stmdev, &pin_int1_cfg);


### PR DESCRIPTION
Sometimes when running the application, the LEDs wouldn't update no matter how you moved the light messenger. I debugged it and noticed that register CTRL_REG3 had a value of "C0" when it worked and a value of "C8" when it didn't work.  In particular section 8.8 of the spec says **This bit must be set to ‘0’ for correct operation of the device.** This fix explicitly sets all of the pin register flags, so we ensure that `not_used_02` is set to 0.