### PR TITLE
Jamisonderek/demo features

### DIFF
--- a/401lightMessengerApp/401LightMsg_acc.c
+++ b/401lightMessengerApp/401LightMsg_acc.c
@@ -528,14 +528,16 @@ void app_scene_acc_on_enter(void* ctx) {
             for(size_t i = 0; i <= len; i++) {
                 if(buf[i] == ' ' || buf[i] == '\0') {
                     buf[i] = '\0';
-                    if(appAcc->bitmapMatrix == NULL) {
-                        appAcc->bitmapMatrix =
-                            bitMatrix_text_create((char*)&buf[0], LightMsgSetFont);
-                        bitMatrix_last = appAcc->bitmapMatrix;
-                    } else {
-                        bitMatrix_last->next_bitmap =
-                            bitMatrix_text_create((char*)&buf[start], LightMsgSetFont);
-                        bitMatrix_last = bitMatrix_last->next_bitmap;
+                    if (strlen(&buf[start])) {
+                        if(appAcc->bitmapMatrix == NULL) {
+                            appAcc->bitmapMatrix =
+                                bitMatrix_text_create((char*)&buf[0], LightMsgSetFont);
+                            bitMatrix_last = appAcc->bitmapMatrix;
+                        } else {
+                            bitMatrix_last->next_bitmap =
+                                bitMatrix_text_create((char*)&buf[start], LightMsgSetFont);
+                            bitMatrix_last = bitMatrix_last->next_bitmap;
+                        }
                     }
                     start = i + 1;
                 }

--- a/401lightMessengerApp/401LightMsg_config.c
+++ b/401lightMessengerApp/401LightMsg_config.c
@@ -120,7 +120,7 @@ const char* const lightmsg_mirror_text[] = {
 
 // Speed (ms) to change text being display (0=never, 1 sec, 0.5 sec)
 const uint32_t lightmsg_speed_value[] = {
-    0,
+    UINT32_MAX,
     1000,
     500,
 };
@@ -456,13 +456,10 @@ AppConfig* app_config_alloc(void* ctx) {
     variable_item_set_current_value_index(item, light_msg_data->tone2);
     variable_item_set_current_value_text(item, lightmsg_tone_text[light_msg_data->tone2]);
 
-    /*
-    // Feature not implemented yet
     item = variable_item_list_add(
         appConfig->list, "Msg Speed", COUNT_OF(lightmsg_speed_text), on_change_speed, app);
     variable_item_set_current_value_index(item, light_msg_data->speed);
     variable_item_set_current_value_text(item, lightmsg_speed_text[light_msg_data->speed]);
-    */
 
 // Activate the accelerometer menu or not.
 #if PARAM_ACCELEROMETER_CONFIG_EN == 1

--- a/401lightMessengerApp/401LightMsg_config.c
+++ b/401lightMessengerApp/401LightMsg_config.c
@@ -182,10 +182,10 @@ const float lightmsg_tone_value[] = {
 
 const char* const lightmsg_tone_text[] = {
     "Off",
-    "Tone 1",
-    "Tone 2",
-    "Tone 3",
-    "Tone 4",
+    "Note 1",
+    "Note 2",
+    "Note 3",
+    "Note 4",
 };
 
 static uint8_t sine_wave[256] = {

--- a/401lightMessengerApp/401LightMsg_config.c
+++ b/401lightMessengerApp/401LightMsg_config.c
@@ -52,7 +52,7 @@ const char* const lightmsg_color_text[] = {
     "R4inb0w", // animated colors
     "Sp4rkl3", // animated colors
     "V4p0rw4v3", // animated colors
-    "R3dGr33n", // alternate colors
+    "R3dBlu3", // alternate colors
 };
 
 // Animation values (callbacks)
@@ -226,7 +226,7 @@ void LightMsg_color_cb_directional(uint16_t tick, bool direction, uint32_t* resu
     UNUSED(tick);
     for(size_t row = 0; row < LIGHTMSG_LED_ROWS; ++row) {
         result[row] = direction ? lightmsg_colors_flat[COLOR_RED] :
-                                  lightmsg_colors_flat[COLOR_GREEN];
+                                  lightmsg_colors_flat[COLOR_BLUE];
     }
 }
 

--- a/401lightMessengerApp/401LightMsg_config.h
+++ b/401lightMessengerApp/401LightMsg_config.h
@@ -73,6 +73,31 @@ typedef enum {
     LightMsg_ColorRainbow
 } LightMsg_Color_index;
 
+// Custom configuration
+typedef enum {
+    LightMsg_MirrorDisabled = 0,
+    LightMsg_MirrorEnabled = 1
+} LightMsg_Mirror;
+
+extern const LightMsg_Mirror lightmsg_mirror_value[];
+extern const char* const lightmsg_mirror_text[];
+
+// Speed (ms) to change text being display (0=never, 1 sec, 0.5 sec)
+extern const uint32_t lightmsg_speed_value[];
+extern const char* const lightmsg_speed_text[];
+
+// Delay in microseconds (us) to wait after rendering a column
+extern const uint32_t lightmsg_width_value[];
+extern const char* const lightmsg_width_text[];
+
+// Max appAcc->cycles before switching directions
+extern const uint16_t lightmsg_accel_value[];
+extern const char* const lightmsg_accel_text[];
+
+// Frequency of the tone when interrupt is detected
+extern const float lightmsg_tone_value[];
+extern const char* const lightmsg_tone_text[];
+
 // Animation labels
 extern const char* const lightmsg_color_text[];
 extern color_animation_callback lightmsg_color_value[];

--- a/401lightMessengerApp/401LightMsg_config.h
+++ b/401lightMessengerApp/401LightMsg_config.h
@@ -82,6 +82,10 @@ typedef enum {
 extern const LightMsg_Mirror lightmsg_mirror_value[];
 extern const char* const lightmsg_mirror_text[];
 
+// Percentage of total swipe to be considered as center
+extern const float lightmsg_center_value[];
+extern const char* const lightmsg_center_text[];
+
 // Speed (ms) to change text being display (0=never, 1 sec, 0.5 sec)
 extern const uint32_t lightmsg_speed_value[];
 extern const char* const lightmsg_speed_text[];
@@ -102,11 +106,12 @@ extern const char* const lightmsg_tone_text[];
 extern const char* const lightmsg_color_text[];
 extern color_animation_callback lightmsg_color_value[];
 
-void LightMsg_color_cb_flat(uint16_t tick, uint32_t* result, void* ctx);
-void LightMsg_color_cb_nyancat(uint16_t tick, uint32_t* result, void* ctx);
-void LightMsg_color_cb_vaporwave(uint16_t tick, uint32_t* result, void* ctx);
-void LightMsg_color_cb_sparkle(uint16_t tick, uint32_t* result, void* ctx);
-void LightMsg_color_cb_rainbow(uint16_t tick, uint32_t* result, void* ctx);
+void LightMsg_color_cb_flat(uint16_t tick, bool direction, uint32_t* result, void* ctx);
+void LightMsg_color_cb_directional(uint16_t tick, bool direction, uint32_t* result, void* ctx);
+void LightMsg_color_cb_nyancat(uint16_t tick, bool direction, uint32_t* result, void* ctx);
+void LightMsg_color_cb_vaporwave(uint16_t tick, bool direction, uint32_t* result, void* ctx);
+void LightMsg_color_cb_sparkle(uint16_t tick, bool direction, uint32_t* result, void* ctx);
+void LightMsg_color_cb_rainbow(uint16_t tick, bool direction, uint32_t* result, void* ctx);
 
 AppConfig* app_config_alloc();
 void app_config_free(AppConfig* appConfig);

--- a/401lightMessengerApp/401_config.c
+++ b/401lightMessengerApp/401_config.c
@@ -43,6 +43,7 @@ void config_default_init(Configuration* config) {
     config->orientation = LIGHTMSG_DEFAULT_ORIENTATION; // Default orientation (e.g., false)
     // version 1.1 features
     config->mirror = LIGHTMSG_DEFAULT_MIRROR;
+    config->center = LIGHTMSG_DEFAULT_CENTER;
     config->speed = LIGHTMSG_DEFAULT_SPEED;
     config->width = LIGHTMSG_DEFAULT_WIDTH;
     config->accel = LIGHTMSG_DEFAULT_ACCEL;
@@ -90,6 +91,7 @@ l401_err config_to_json(Configuration* config, char** jsontxt) {
 
     // Add version 1.1 features
     cJSON_AddBoolToObject(json, "mirror", config->mirror);
+    cJSON_AddNumberToObject(json, "center", config->center);
     cJSON_AddNumberToObject(json, "speed", config->speed);
     cJSON_AddNumberToObject(json, "width", config->width);
     cJSON_AddNumberToObject(json, "accel", config->accel);
@@ -152,6 +154,7 @@ l401_err json_to_config(char* jsontxt, Configuration* config) {
 
     // Optional fields (version 1.1)
     cJSON* json_mirror = cJSON_GetObjectItemCaseSensitive(json, "mirror");
+    cJSON* json_center = cJSON_GetObjectItemCaseSensitive(json, "center");
     cJSON* json_speed = cJSON_GetObjectItemCaseSensitive(json, "speed");
     cJSON* json_width = cJSON_GetObjectItemCaseSensitive(json, "width");
     cJSON* json_accel = cJSON_GetObjectItemCaseSensitive(json, "accel");
@@ -180,14 +183,15 @@ l401_err json_to_config(char* jsontxt, Configuration* config) {
 
     // version 1.1+ features
     if(cJSON_IsBool(json_mirror)) {
-        if(!cJSON_IsNumber(json_speed) || !cJSON_IsNumber(json_width) ||
-           !cJSON_IsNumber(json_accel) || !cJSON_IsNumber(json_tone1) ||
-           !cJSON_IsNumber(json_tone2)) {
+        if(!cJSON_IsNumber(json_center) || !cJSON_IsNumber(json_speed) ||
+           !cJSON_IsNumber(json_width) || !cJSON_IsNumber(json_accel) ||
+           !cJSON_IsNumber(json_tone1) || !cJSON_IsNumber(json_tone2)) {
             cJSON_Delete(json);
             FURI_LOG_E(TAG, "Error: Malformed v1.1 configuration");
             return L401_ERR_MALFORMED;
         }
         config->mirror = cJSON_IsTrue(json_mirror) ? true : false;
+        config->center = (uint8_t)json_center->valuedouble;
         config->speed = (uint8_t)json_speed->valuedouble;
         config->width = (uint8_t)json_width->valuedouble;
         config->accel = (uint8_t)json_accel->valuedouble;
@@ -200,6 +204,7 @@ l401_err json_to_config(char* jsontxt, Configuration* config) {
             config->version = strdup(LIGHTMSG_VERSION);
         }
         config->mirror = LIGHTMSG_DEFAULT_MIRROR;
+        config->center = LIGHTMSG_DEFAULT_CENTER;
         config->speed = LIGHTMSG_DEFAULT_SPEED;
         config->width = LIGHTMSG_DEFAULT_WIDTH;
         config->accel = LIGHTMSG_DEFAULT_ACCEL;

--- a/401lightMessengerApp/401_config.h
+++ b/401lightMessengerApp/401_config.h
@@ -19,6 +19,7 @@
 #define LIGHTMSG_DEFAULT_BITMAPPATH  LIGHTMSGCONF_SAVE_FOLDER
 
 #define LIGHTMSG_DEFAULT_MIRROR 0
+#define LIGHTMSG_DEFAULT_CENTER 8
 #define LIGHTMSG_DEFAULT_SPEED  0
 #define LIGHTMSG_DEFAULT_WIDTH  1
 #define LIGHTMSG_DEFAULT_ACCEL  0
@@ -28,7 +29,8 @@
 #include "401_err.h"
 #include "app_params.h"
 
-typedef void (*color_animation_callback)(uint16_t tick, uint32_t* result, void* ctx);
+typedef void (
+    *color_animation_callback)(uint16_t tick, bool direction, uint32_t* result, void* ctx);
 typedef struct {
     char* version;
     char text[LIGHTMSG_MAX_TEXT_LEN + 1];
@@ -39,6 +41,7 @@ typedef struct {
     color_animation_callback cb;
     // New features
     bool mirror; // true = mirror, false = no mirror
+    uint8_t center; // center index
     uint8_t speed; // speed index
     uint8_t width; // width index
     uint8_t accel; // acceleration index

--- a/401lightMessengerApp/401_config.h
+++ b/401lightMessengerApp/401_config.h
@@ -11,12 +11,20 @@
 #include <storage/storage.h>
 #include <toolbox/path.h>
 // #include "401LightMsg_config.h"
-#define LIGHTMSG_VERSION             "1.0"
+#define LIGHTMSG_VERSION             "1.1"
 #define LIGHTMSG_DEFAULT_ORIENTATION 0
 #define LIGHTMSG_DEFAULT_BRIGHTNESS  3
 #define LIGHTMSG_DEFAULT_COLOR       1
 #define LIGHTMSG_DEFAULT_TEXT        "Lab401"
 #define LIGHTMSG_DEFAULT_BITMAPPATH  LIGHTMSGCONF_SAVE_FOLDER
+
+#define LIGHTMSG_DEFAULT_MIRROR 0
+#define LIGHTMSG_DEFAULT_SPEED  0
+#define LIGHTMSG_DEFAULT_WIDTH  1
+#define LIGHTMSG_DEFAULT_ACCEL  0
+#define LIGHTMSG_DEFAULT_TONE1  0
+#define LIGHTMSG_DEFAULT_TONE2  0
+
 #include "401_err.h"
 #include "app_params.h"
 
@@ -29,6 +37,13 @@ typedef struct {
     uint8_t brightness;
     bool orientation;
     color_animation_callback cb;
+    // New features
+    bool mirror; // true = mirror, false = no mirror
+    uint8_t speed; // speed index
+    uint8_t width; // width index
+    uint8_t accel; // acceleration index
+    uint8_t tone1; // tone index when first interrupt is detected
+    uint8_t tone2; // tone index when second interrupt is detected
 } Configuration;
 
 l401_err config_alloc(Configuration** config);

--- a/401lightMessengerApp/app_params.h
+++ b/401lightMessengerApp/app_params.h
@@ -41,8 +41,9 @@
 #define PARAM_OPERATION_MODE          LIS2DH12_HR_12bit // Set operation mode to high-resolution mode
 
 // Additional configurations
-#define PARAM_SHADER_RAINBOW_IS_SINE 0
-#define PARAM_BRIGHTNESS_CONFIG_EN   0
+#define PARAM_SHADER_RAINBOW_IS_SINE  0
+#define PARAM_BRIGHTNESS_CONFIG_EN    0
+#define PARAM_ACCELEROMETER_CONFIG_EN 0
 
 #define PARAM_BMP_EDITOR_MIN_RES_W 16
 #define PARAM_BMP_EDITOR_MAX_RES_W 41

--- a/401lightMessengerApp/app_params.h
+++ b/401lightMessengerApp/app_params.h
@@ -9,7 +9,7 @@
 
 // General Light Message configurations
 #define LIGHTMSG_LED_ROWS           16
-#define LIGHTMSG_MAX_TEXT_LEN       16
+#define LIGHTMSG_MAX_TEXT_LEN       64 // Maximum len animated text message (max 25 displayed at once)
 #define LIGHTMSG_MAX_BITMAPPATH_LEN 128
 #define LIGHTMSG_MAX_BITMAPNAME_LEN 32
 

--- a/401lightMessengerApp/bmp.c
+++ b/401lightMessengerApp/bmp.c
@@ -34,6 +34,10 @@ void bitmapMatrix_free(bitmapMatrix* bitMatrix) {
         free(bitMatrix->array[i]);
     }
     free(bitMatrix->array);
+    if(bitMatrix->next_bitmap) {
+        bitmapMatrix_free((bitmapMatrix*)bitMatrix->next_bitmap);
+        bitMatrix->next_bitmap = NULL;
+    }
     free(bitMatrix);
 }
 
@@ -187,6 +191,7 @@ bitmapMatrix* bmp_to_bitmapMatrix(const char* path) {
     bitMatrix->height = image.info_header.biHeight;
 
     bitMatrix->array = malloc(image.info_header.biHeight * sizeof(uint8_t*));
+    bitMatrix->next_bitmap = NULL;
 
     row_padded = (image.info_header.biWidth + 7) / 8;
     row_padded = (row_padded + 3) & (~3);

--- a/401lightMessengerApp/bmp.h
+++ b/401lightMessengerApp/bmp.h
@@ -61,6 +61,7 @@ typedef struct {
     uint8_t width;
     uint8_t height;
     uint8_t** array;
+    void* next_bitmap;
 } bitmapMatrix;
 
 typedef struct {


### PR DESCRIPTION
I'm not sure if you want all of these modifications?  It contains all of the features I added to the Light Messenger.  My goal was to show the extensibility of the product for an upcoming YouTube video.

When run, it will upgrade the config.json to version 1.1 format (which contains additional properties). The goal was to have all defaults be expected values, so that there should be no impact to the user.

- **Mirror** is `Disabled` by default. If you set to `Enabled` then the Light Messenger will render text as a mirror image. I found this helpful as I wanted to see what it looked like in a physical mirror (rather than a camera that captures frames).
- **Center** is `33.33%` by default. This is the value used to scale where the center point is considered. The original code was dividing by 3, but now it takes the percentage specified here. You can use this to adjust if Left/Right aren't in alignment.
- I added a new color **R3dBlu3** which is Red when swiping one direction and Blue when swiping the other. This helps with determining the calibration of the Center value. Red/Blue flashing is scary when you catch it out of the corner of your eye. 🤣
- **Width** is `Normal` by default. This is how long the uS sleep is. If you set to `Narrow` the sleep is less than original, and `Wide` the sleep is more than original.
- **Tone1/Tone2** is `Off` by default. If Tone1 or Tone 2 is set to `Note1`, `Note2`, `Note3` or `Note4` then a sound will be heard when swiping left or right.
- **Msg Speed** is `Off` by default. This means the entire typed message will be displayed. If you set to `Slow` then once a second it will display the next word in the message (helpful for a countdown). If you set to `Fast` then every 1/2 second it will display the next word in the message. Once the message is complete, it will vibrate, the restart.
- If **PARAM_ACCELEROMETER_CONFIG_EN** is defined in `app_param.h` then a **Motion** configuration item will be displayed. The default value of `Accel` will use the LIS2DH12 accelerometer interrupts. If you instead use `Slow`, `Normal` or `Fast` the timing is automatic. It's non-trivial to move at the correct rate to keep the message rendering properly, but if you turn on sound, you might have a chance! It's a good example of how the LIS2DH12 helps time the message. You can also place the messenger on a desk and shake your head to see the message. 🤡