### PR TITLE
Fix issue where app exit takes a long time.

### DIFF
--- a/401lightMessengerApp/401LightMsg_acc.c
+++ b/401lightMessengerApp/401LightMsg_acc.c
@@ -215,11 +215,16 @@ static int32_t app_acc_worker(void* ctx) {
     uint8_t end_message_count = 0;
 
     uint32_t message_duration_ms = lightmsg_speed_value[light_msg_data->speed];
+    uint32_t flush_counter = 0;
 
     while(running) {
         // Checks if the thread must be ended.
         if(furi_thread_flags_get()) {
             running = false;
+        }
+        if(flush_counter++ > 12000) {
+            flush_counter = 0;
+            furi_timer_flush();
         }
         if(time++ == 4000) {
             notification_message(app->notifications, &sequence_display_backlight_off);


### PR DESCRIPTION
Repro:
- Run the Light Messenger app with message of "Lab401".
- Leave app running for 15 minutes.
- Press back (text enter screen)
- Press back (main menu screen)
- Press back (exit application)
  - **Actual**: Application takes a long time to exit (15+ seconds of hourglass).
  - **Expected**: Application exits quickly.

I tracked it down to `furi_timer_flush` taking a long time to execute. I tried refactoring code so that we don't allocate a timer in `app_config_alloc` but instead in `app_scene_config_on_enter`.  This fixed the first hang spot, but we still get a hang on the `text_input_free` call (since it also frees a timer). We can't avoid using that timer, so instead we call `furi_timer_flush` every 12000 cycles.