### PR TITLE
added quick fix for older core's versions

### DIFF
--- a/401lightMessengerApp/401LightMsg_acc.c
+++ b/401lightMessengerApp/401LightMsg_acc.c
@@ -11,9 +11,20 @@
 #include "font.h"
 #include "gui/gui.h"
 #include "gui/view_dispatcher.h"
+
 #define PI  3.14159
 #define PI3 PI / 3
 static const char* TAG = "401_LightMsgAcc";
+
+/*
+  As pointed out by @jamisonderek, furi_timer_flush isn't present on older
+  versions of flipper's core, which is used by some alternative firmwares.
+  This quickly fixes the missing function, and may be used to implement
+  workarounds in the future
+*/
+#pragma weak furi_timer_flush
+void furi_timer_flush(void) {
+}
 
 /**
 

--- a/401lightMessengerApp/CHANGELOG.md
+++ b/401lightMessengerApp/CHANGELOG.md
@@ -12,3 +12,6 @@ v1.3
 - Fixes and enhancement in display model
 - Added authentic bitmaps 2000's operator logos as assets
 - Changed apps_data to apps_assetsfor storing datas and bitmaps
+
+v1.3.1
+- Workaround for allowing older core to compile while maintaining current core fixes.

--- a/401lightMessengerApp/application.fam
+++ b/401lightMessengerApp/application.fam
@@ -11,5 +11,5 @@ App(
     fap_icon="images/401_lghtmsg_icon_10px.png",
     fap_category="GPIO",
     fap_icon_assets="images",
-    fap_version="1.3",
+    fap_version="1.3.1",
 )


### PR DESCRIPTION
As pointed out by @jamisonderek, furi_timer_flush isn't present on older versions of flipper's core, which is used by some  alternative firmwares. This quickly fixes the missing function, and may be used to implement better solutions in the future.