### PR TITLE
Fix warnings

### DIFF
--- a/401lightMessengerApp/401LightMsg_acc.c
+++ b/401lightMessengerApp/401LightMsg_acc.c
@@ -9,7 +9,6 @@
 #include "401LightMsg_config.h"
 #include "bmp.h"
 #include "font.h"
-#include "gui/gui.h"
 #include "gui/view_dispatcher.h"
 
 #define PI  3.14159

--- a/401lightMessengerApp/401LightMsg_acc.h
+++ b/401lightMessengerApp/401LightMsg_acc.h
@@ -45,7 +45,7 @@ typedef struct AppAcc {
 
 #include "401LightMsg_main.h"
 
-AppAcc* app_acc_alloc();
+AppAcc* app_acc_alloc(void* ctx);
 View* app_acc_get_view(AppAcc* appAcc);
 void app_acc_render_callback(Canvas* canvas, void* model);
 void app_acc_free(AppAcc* appAcc);

--- a/401lightMessengerApp/401LightMsg_bmp_editor.h
+++ b/401lightMessengerApp/401LightMsg_bmp_editor.h
@@ -97,7 +97,7 @@ typedef enum {
     AppBmpEditorEventSaveText,
 } AppBmpEditorCustomEvents;
 
-AppBmpEditor* app_bmp_editor_alloc();
+AppBmpEditor* app_bmp_editor_alloc(void* ctx);
 void app_bmp_editor_free(void* ctx);
 View* app_bitmap_editor_get_view(AppBmpEditor* appBmpEditor);
 void app_scene_bmp_editor_on_enter(void* context);

--- a/401lightMessengerApp/401LightMsg_config.c
+++ b/401lightMessengerApp/401LightMsg_config.c
@@ -368,7 +368,7 @@ void on_change_width(VariableItem* item) {
 
 /**
  * @brief Allocate memory and initialize the app configuration.
- *
+ * @param ctx The application context.
  * @return Returns a pointer to the allocated AppConfig.
  */
 

--- a/401lightMessengerApp/401LightMsg_config.h
+++ b/401lightMessengerApp/401LightMsg_config.h
@@ -104,7 +104,7 @@ extern const char* const lightmsg_speed_text[];
 extern const uint32_t lightmsg_width_value[];
 extern const char* const lightmsg_width_text[];
 
-AppConfig* app_config_alloc();
+AppConfig* app_config_alloc(void* ctx);
 void app_config_free(AppConfig* appConfig);
 View* app_config_get_view(AppConfig* appConfig);
 void app_scene_config_on_enter(void* ctx);

--- a/401lightMessengerApp/401LightMsg_set_text.c
+++ b/401lightMessengerApp/401LightMsg_set_text.c
@@ -5,6 +5,7 @@
  *    + Tixlegeek
  */
 #include "401LightMsg_set_text.h"
+#include "401LightMsg_main.h"
 
 static const char* TAG = "401_LightMsgSetText";
 /**

--- a/401lightMessengerApp/401LightMsg_set_text.h
+++ b/401lightMessengerApp/401LightMsg_set_text.h
@@ -18,7 +18,6 @@
 #include <gui/scene_manager.h>
 #include <gui/view_dispatcher.h>
 
-#include "401LightMsg_main.h"
 
 typedef enum {
     SetTextInputSaveEvent,

--- a/401lightMessengerApp/401LightMsg_splash.h
+++ b/401lightMessengerApp/401LightMsg_splash.h
@@ -31,7 +31,7 @@ typedef enum {
     AppSplashEventRoll,
 } AppSplashCustomEvents;
 
-AppSplash* app_splash_alloc();
+AppSplash* app_splash_alloc(void* ctx);
 void app_splash_free(AppSplash* appSplash);
 View* app_splash_get_view(AppSplash* appSplash);
 void app_scene_splash_on_enter(void* context);

--- a/401lightMessengerApp/401_config.c
+++ b/401lightMessengerApp/401_config.c
@@ -32,12 +32,12 @@ void config_default_init(Configuration* config) {
     // Initialize with default values
     config->version = strdup(LIGHTMSG_VERSION); // Default version
     strncpy(config->text, LIGHTMSG_DEFAULT_TEXT, LIGHTMSG_MAX_TEXT_LEN); // Default text
-    config->text[LIGHTMSG_MAX_TEXT_LEN + 1] = '\0';
+    config->text[LIGHTMSG_MAX_TEXT_LEN] = '\0';
     strncpy(
         config->bitmapPath,
         LIGHTMSG_DEFAULT_BITMAPPATH,
         LIGHTMSG_MAX_BITMAPPATH_LEN); // Default text
-    config->bitmapPath[LIGHTMSG_MAX_BITMAPPATH_LEN + 1] = '\0';
+    config->bitmapPath[LIGHTMSG_MAX_BITMAPPATH_LEN] = '\0';
     config->color = LIGHTMSG_DEFAULT_COLOR; // Default color
     config->brightness = LIGHTMSG_DEFAULT_BRIGHTNESS; // Default brightness
     config->sensitivity = LIGHTMSG_DEFAULT_SENSIBILITY; // Default sensitivity

--- a/401lightMessengerApp/401_config.c
+++ b/401lightMessengerApp/401_config.c
@@ -293,7 +293,7 @@ l401_err config_load_json(const char* filename, Configuration* config) {
 
     Storage* storage = furi_record_open(RECORD_STORAGE);
     // Check if configuration file exists
-    if(!storage_common_stat(storage, filename, NULL) == FSE_OK) {
+    if(storage_common_stat(storage, filename, NULL) != FSE_OK) {
         // Create it if it doesn't exists
         if(config_create_json(filename, config) != L401_OK) {
             FURI_LOG_E(TAG, "Could not create configuration file %s", filename);

--- a/401lightMessengerApp/drivers/sk6805.h
+++ b/401lightMessengerApp/drivers/sk6805.h
@@ -19,7 +19,7 @@
 #ifndef SK6805_H_
 #define SK6805_H_
 
-#include "app_params.h" // Application specific configuration
+#include "../app_params.h" // Application specific configuration
 #include <furi.h>
 
 /**


### PR DESCRIPTION
Code clean-up, so no warnings in my editor...
- A bunch of allocators take a context that was missing in the header file definitions.
- Unused header files were removed.
- set_text header had recursive error, rather than create an internal header, just included main.h in the .c file.
