### PR TITLE
Jamisonderek/autodetect

### DIFF
--- a/401lightMessengerApp/401LightMsg_acc.c
+++ b/401lightMessengerApp/401LightMsg_acc.c
@@ -445,11 +445,11 @@ static bool set_bitmap_dialog(void* ctx) {
                 FURI_LOG_I(
                     TAG, "Successfully saved configuration to %s.", LIGHTMSGCONF_CONFIG_FILE);
             } else {
-                l401_sign_app(res);
+                l401_sign_app(res, app);
                 set = false;
             }
         } else {
-            l401_sign_app(L401_ERR_BMP_FILE);
+            l401_sign_app(L401_ERR_BMP_FILE, app);
             set = false;
         }
     }

--- a/401lightMessengerApp/401LightMsg_main.c
+++ b/401lightMessengerApp/401LightMsg_main.c
@@ -248,23 +248,23 @@ void app_free(AppContext* app_ctx) {
     furi_assert(app_ctx);
 
     // Free AppViewSplash
-        view_dispatcher_remove_view(app_ctx->view_dispatcher, AppViewSplash);
-        app_splash_free(app_ctx->sceneSplash);
+    view_dispatcher_remove_view(app_ctx->view_dispatcher, AppViewSplash);
+    app_splash_free(app_ctx->sceneSplash);
     // Free AppViewConfig
-        view_dispatcher_remove_view(app_ctx->view_dispatcher, AppViewConfig);
-        app_config_free(app_ctx->sceneConfig);
+    view_dispatcher_remove_view(app_ctx->view_dispatcher, AppViewConfig);
+    app_config_free(app_ctx->sceneConfig);
     // Free AppViewAcc
-        view_dispatcher_remove_view(app_ctx->view_dispatcher, AppViewAcc);
-        app_acc_free(app_ctx->sceneAcc);
+    view_dispatcher_remove_view(app_ctx->view_dispatcher, AppViewAcc);
+    app_acc_free(app_ctx->sceneAcc);
     // Free BMP Editor
-        view_dispatcher_remove_view(app_ctx->view_dispatcher, AppViewBmpEditor);
-        app_bmp_editor_free(app_ctx);
+    view_dispatcher_remove_view(app_ctx->view_dispatcher, AppViewBmpEditor);
+    app_bmp_editor_free(app_ctx);
     // Free AppViewSetText
-        view_dispatcher_remove_view(app_ctx->view_dispatcher, AppViewSetText);
-        text_input_free(app_ctx->sceneSetText);
+    view_dispatcher_remove_view(app_ctx->view_dispatcher, AppViewSetText);
+    text_input_free(app_ctx->sceneSetText);
     // Free AppViewMainMenu
-        view_dispatcher_remove_view(app_ctx->view_dispatcher, AppViewMainMenu);
-        submenu_free(app_ctx->mainmenu);
+    view_dispatcher_remove_view(app_ctx->view_dispatcher, AppViewMainMenu);
+    submenu_free(app_ctx->mainmenu);
 
     view_dispatcher_free(app_ctx->view_dispatcher);
     scene_manager_free(app_ctx->scene_manager);

--- a/401lightMessengerApp/401LightMsg_main.c
+++ b/401lightMessengerApp/401LightMsg_main.c
@@ -5,6 +5,7 @@
  *    + Tixlegeek
  */
 #include "401LightMsg_main.h"
+#include "401_err.h"
 
 //#include <assets_icons.h>
 static const char* TAG = "401_LightMsg";
@@ -116,7 +117,7 @@ uint32_t app_navigateTo_Splash_callback(void* ctx) {
     return AppViewSplash;
 }
 
-l401_err check_hat(AppContext* app) {
+l401_err check_hat(void* app) {
     furi_assert(app);
     AppContext* app_ctx = app;
     uint8_t acc_id = 0;
@@ -247,23 +248,23 @@ void app_free(AppContext* app_ctx) {
     furi_assert(app_ctx);
 
     // Free AppViewSplash
-    view_dispatcher_remove_view(app_ctx->view_dispatcher, AppViewSplash);
-    app_splash_free(app_ctx->sceneSplash);
+        view_dispatcher_remove_view(app_ctx->view_dispatcher, AppViewSplash);
+        app_splash_free(app_ctx->sceneSplash);
     // Free AppViewConfig
-    view_dispatcher_remove_view(app_ctx->view_dispatcher, AppViewConfig);
-    app_config_free(app_ctx->sceneConfig);
+        view_dispatcher_remove_view(app_ctx->view_dispatcher, AppViewConfig);
+        app_config_free(app_ctx->sceneConfig);
     // Free AppViewAcc
-    view_dispatcher_remove_view(app_ctx->view_dispatcher, AppViewAcc);
-    app_acc_free(app_ctx->sceneAcc);
+        view_dispatcher_remove_view(app_ctx->view_dispatcher, AppViewAcc);
+        app_acc_free(app_ctx->sceneAcc);
     // Free BMP Editor
-    view_dispatcher_remove_view(app_ctx->view_dispatcher, AppViewBmpEditor);
-    app_bmp_editor_free(app_ctx);
+        view_dispatcher_remove_view(app_ctx->view_dispatcher, AppViewBmpEditor);
+        app_bmp_editor_free(app_ctx);
     // Free AppViewSetText
-    view_dispatcher_remove_view(app_ctx->view_dispatcher, AppViewSetText);
-    text_input_free(app_ctx->sceneSetText);
+        view_dispatcher_remove_view(app_ctx->view_dispatcher, AppViewSetText);
+        text_input_free(app_ctx->sceneSetText);
     // Free AppViewMainMenu
-    view_dispatcher_remove_view(app_ctx->view_dispatcher, AppViewMainMenu);
-    submenu_free(app_ctx->mainmenu);
+        view_dispatcher_remove_view(app_ctx->view_dispatcher, AppViewMainMenu);
+        submenu_free(app_ctx->mainmenu);
 
     view_dispatcher_free(app_ctx->view_dispatcher);
     scene_manager_free(app_ctx->scene_manager);
@@ -286,7 +287,7 @@ void app_free(AppContext* app_ctx) {
 int32_t lightMsg_app(void* p) {
     UNUSED(p);
     AppContext* app_ctx = app_alloc();
-    FURI_LOG_I(TAG, "Start Lab401's LighMsg app");
+    FURI_LOG_I(TAG, "Start Lab401's LightMsg app");
     if(app_ctx->err == L401_OK) {
         with_view_model(
             app_splash_get_view(app_ctx->sceneSplash),
@@ -297,7 +298,24 @@ int32_t lightMsg_app(void* p) {
         app_free(app_ctx);
         furi_record_close(RECORD_GUI);
     } else {
-        l401_sign_app(app_ctx->err);
+        uint32_t status = l401_sign_app(app_ctx->err, app_ctx);
+        bool retry = (app_ctx->err == L401_ERR_HARDWARE && status == 0);
+        free(app_ctx->data);
+        app_ctx->data = NULL;
+        submenu_free(app_ctx->mainmenu);
+        app_ctx->mainmenu = NULL;
+        view_dispatcher_free(app_ctx->view_dispatcher);
+        app_ctx->view_dispatcher = NULL;
+        scene_manager_free(app_ctx->scene_manager);
+        app_ctx->scene_manager = NULL;
+        furi_record_close(RECORD_NOTIFICATION);
+        furi_record_close(RECORD_GUI);
+        free(app_ctx);
+        app_ctx = NULL;
+
+        if (retry) {
+            lightMsg_app(NULL);
+        }
     }
 
     return 0;

--- a/401lightMessengerApp/401_sign.h
+++ b/401lightMessengerApp/401_sign.h
@@ -16,6 +16,12 @@
 #include <401_light_msg_icons.h>
 #include "401_err.h"
 
-int32_t l401_sign_app(l401_err err);
+int32_t l401_sign_app(l401_err err, void* app_context);
+
+typedef struct {
+    FuriSemaphore* semaphore;
+    void* app_context;
+    int32_t status_code;
+} SignContext;
 
 #endif /* end of include guard: L401_SIGN_H_ */


### PR DESCRIPTION
In [TakingSasquach video](https://youtu.be/L6JhQkFYx3Q?si=vD8SZ2cwlifT1UQr&t=830) he tries to connect the hardware device after the app was launched. This code change will poll for new hardware every second, and if detected, it will restart the app.

We could refactor check_hat function & clean up the app_free code, but I don't see anyone else participating in the code so not sure it's worth the effort (unless you plan on adding more features).
